### PR TITLE
Mini code refactor

### DIFF
--- a/src/components/mini-code/mini-code.jsx
+++ b/src/components/mini-code/mini-code.jsx
@@ -41,6 +41,8 @@ const MiniEditor = props => {
     const [codeToRun, setCodeToRun] = useState(initialCode);
     
     const reset = () => {
+        // Clear any error
+        setError('');
         // Display the initial code in the editor
         setUpdatedCode(initialCode);
         // Run the initial code
@@ -54,7 +56,7 @@ const MiniEditor = props => {
         // Resetting the error here ensures that the error stays displayed if the user
         // clicks play several times (without updating any of the code)
 
-        // Reset the error
+        // Clear any error
         setError('');
         // Run the updated code
         setCodeToRun(updatedCode);

--- a/src/components/mini-code/mini-code.jsx
+++ b/src/components/mini-code/mini-code.jsx
@@ -39,7 +39,23 @@ const MiniEditor = props => {
     // Code to run is updated when we click the play or reset buttons
     // (which then triggers the useEffect hook)
     const [codeToRun, setCodeToRun] = useState(initialCode);
+
+    // A silly piece of state that updates whenever we click the play or reset buttons
+    // this is to ensure that we actually trigger the useEffect hook again if we
+    // click play or reset again and again without changing the code.
+    const [playCount, setPlayCount] = useState(0);
+
+    const [editorVisible, setEditorVisible] = useState(!props.editorDisabled && !props.hideEditor);
     
+    const handlePlayClick = () => {
+        // Clear any error
+        setError('');
+        // Run the updated code
+        setCodeToRun(updatedCode);
+        // Ensure play runs when clicked even if nothing above has changed
+        setPlayCount(c => c + 1);
+    };
+
     const reset = () => {
         // Clear any error
         setError('');
@@ -47,19 +63,8 @@ const MiniEditor = props => {
         setUpdatedCode(initialCode);
         // Run the initial code
         setCodeToRun(initialCode);
-    };
-
-    const [editorVisible, setEditorVisible] = useState(!props.editorDisabled && !props.hideEditor);
-    
-    const handlePlayClick = () => {
-        // The useEffect hook is also triggered on error state change
-        // Resetting the error here ensures that the error stays displayed if the user
-        // clicks play several times (without updating any of the code)
-
-        // Clear any error
-        setError('');
-        // Run the updated code
-        setCodeToRun(updatedCode);
+        // Ensure reset runs when clicked even if nothing above has changed
+        setPlayCount(c => c + 1);
     };
 
     useEffect(() => {
@@ -90,7 +95,7 @@ const MiniEditor = props => {
             myP5.remove();
         };
 
-    }, [codeLang, baseSketchFun, codeToRun, error]); // codeToRun and error are the only ones that should actually change
+    }, [codeLang, baseSketchFun, codeToRun, playCount]); // codeToRun and playCount are the only ones that should actually change
 
 	const toggleEditor = () => {
 		setEditorVisible(!editorVisible);


### PR DESCRIPTION
Refactor mini code component to use state to trigger useEffect hook.

- [ ] Play function moved inside of useEffect hook
- [ ] Play button click now updates the component state instead of running the play function directly.
- [ ] The useEffect hook relies on state changes as dependencies
- [ ] Separate out the 'updatedCode' state (which changes whenever the user types something in the editor) and the 'codeToRun' state which triggers the useEffect hook.
- [ ] Error state also triggers the useEffect hook and the error state is reset every time the play button is clicked.

Let's test all of the bugs we've encountered in the past...

- [ ] we shouldn't have any double canvases
- [ ] typing / changing the code should not trigger re-running the code automatically
- [ ] play button should update the canvas or display an error (there should never be a blank space where the canvas/error should be)
- [ ] reset button should reset the code inside of the editor text area as well as re-run the code (any previous error should be cleared)